### PR TITLE
Fix build error when trying to compile for Ghidra 11.x

### DIFF
--- a/src/main/help/help/topics/fooloader/help.html
+++ b/src/main/help/help/topics/fooloader/help.html
@@ -10,7 +10,7 @@
     <META name="ProgId" content="FrontPage.Editor.Document">
 
     <TITLE>Skeleton Help File for a Module</TITLE>
-    <LINK rel="stylesheet" type="text/css" href="../../shared/Frontpage.css">
+    <LINK rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
   </HEAD>
 
   <BODY>


### PR DESCRIPTION
SetPointerIndex changed return value from void to long so could no longer use the 10.x release.
When rebuilding ran into error about css file.
This will fix that error and allow project be rebuilt.